### PR TITLE
Changes for compatibility with spack

### DIFF
--- a/Make/MkFlags
+++ b/Make/MkFlags
@@ -1,4 +1,8 @@
 #Compiler
-CC = mpicc
-CFLAGS = -std=c99 -O3
-LDFLAGS =
+# Set these variables either here or in the environment. See
+# https://www.gnu.org/software/make/manual/html_node/Implicit-Variables.html
+# If you are using Spack, leave these commented out
+# (Spack will manage them when building)
+# CC = mpicc
+# CFLAGS = -std=c99 -O3
+# LDFLAGS =

--- a/Make/MkFlags
+++ b/Make/MkFlags
@@ -3,6 +3,6 @@
 # https://www.gnu.org/software/make/manual/html_node/Implicit-Variables.html
 # If you are using Spack, leave these commented out
 # (Spack will manage them when building)
-# CC = mpicc
+# MPICC = mpicc
 # CFLAGS = -std=c99 -O3
 # LDFLAGS =

--- a/Make/MkFlags.A64FX
+++ b/Make/MkFlags.A64FX
@@ -1,6 +1,6 @@
 #Include this file at the end of MkFlags
 
 #Compiler
-CC = mpifccpx
+MPICC = mpifccpx
 CFLAGS = -std=c99 -O3
 

--- a/Make/MkFlags.AArch64
+++ b/Make/MkFlags.AArch64
@@ -1,6 +1,6 @@
 #Include this file at the end of MkFlags
 
 #Compiler
-CC = mpicc
+MPICC = mpicc
 
 CFLAGS = -std=c99 -O3

--- a/Make/MkFlags.OpenPOWER
+++ b/Make/MkFlags.OpenPOWER
@@ -1,6 +1,6 @@
 #Include this file at the end of MkFlags
 
 #Compiler
-CC =  mpcc_r
+MPICC =  mpcc_r
 
 CFLAGS = -q64 -O4 -qarch=pwr5 -qtune=pwr5 -qstrict

--- a/Make/MkFlags.x86-64
+++ b/Make/MkFlags.x86-64
@@ -1,6 +1,6 @@
 #Include this file at the end of MkFlags
 
 #Compiler
-CC = mpicc
+MPICC = mpicc
 CFLAGS = -std=c99 -O3 
 

--- a/Make/MkFlags.x86-64_alt
+++ b/Make/MkFlags.x86-64_alt
@@ -1,6 +1,6 @@
 #Include this file at the end of MkFlags
 
 #Compiler
-CC = mpicc
+MPICC = mpicc
 CFLAGS = -wd593 -wd188 -wd981 -wd177 -wd869 -std=c99 -O2
 

--- a/Make/MkRules
+++ b/Make/MkRules
@@ -126,37 +126,37 @@ $(COUNTERSFULLPATHS):
 sombrero/sombrero1: sombrero/su2/sombrero.o sombrero/su2/hmc_utils.o \
     $(TOPDIR)/LibHR/libhr_su2.a $(COUNTERSFULLPATHS)
 	echo $(_col_link)Linking$(_col_norm) $(call _cfname,$@)... 
-	$(CC) -o $@ $^ $(CFLAGS) -LLibHR -lhr_su2 -lm \
+	$(MPICC) -o $@ $^ $(CFLAGS) -LLibHR -lhr_su2 -lm \
     -L$(COUNTERSLDIR) $(pathsub lib%.o, -l%, $(COUNTERS));
 
 sombrero/sombrero2: sombrero/su2adj/sombrero.o sombrero/su2adj/hmc_utils.o \
     $(TOPDIR)/LibHR/libhr_su2adj.a $(COUNTERSFULLPATHS)
 	echo $(_col_link)Linking$(_col_norm) $(call _cfname,$@)... 
-	$(CC) -o $@ $^ $(CFLAGS) -LLibHR -lhr_su2adj -lm \
+	$(MPICC) -o $@ $^ $(CFLAGS) -LLibHR -lhr_su2adj -lm \
     -L$(COUNTERSLDIR) $(pathsub lib%.o, -l%, $(COUNTERS));
 
 sombrero/sombrero3: sombrero/su3/sombrero.o sombrero/su3/hmc_utils.o \
     $(TOPDIR)/LibHR/libhr_su3.a $(COUNTERSFULLPATHS)
 	echo $(_col_link)Linking$(_col_norm) $(call _cfname,$@)... 
-	$(CC) -o $@ $^ $(CFLAGS) -LLibHR -lhr_su3 -lm \
+	$(MPICC) -o $@ $^ $(CFLAGS) -LLibHR -lhr_su3 -lm \
     -L$(COUNTERSLDIR) $(pathsub lib%.o, -l%, $(COUNTERS));
 
 sombrero/sombrero4: sombrero/sp4/sombrero.o sombrero/sp4/hmc_utils.o \
     $(TOPDIR)/LibHR/libhr_sp4.a $(COUNTERSFULLPATHS)
 	echo $(_col_link)Linking$(_col_norm) $(call _cfname,$@)... 
-	$(CC) -o $@ $^ $(CFLAGS) -LLibHR -lhr_sp4 -lm \
+	$(MPICC) -o $@ $^ $(CFLAGS) -LLibHR -lhr_sp4 -lm \
     -L$(COUNTERSLDIR) $(pathsub lib%.o, -l%, $(COUNTERS));
 
 sombrero/sombrero5: sombrero/su3sym/sombrero.o sombrero/su3sym/hmc_utils.o \
     $(TOPDIR)/LibHR/libhr_su3sym.a $(COUNTERSFULLPATHS)
 	echo $(_col_link)Linking$(_col_norm) $(call _cfname,$@)... 
-	$(CC) -o $@ $^ $(CFLAGS) -LLibHR -lhr_su3sym -lm \
+	$(MPICC) -o $@ $^ $(CFLAGS) -LLibHR -lhr_su3sym -lm \
     -L$(COUNTERSLDIR) $(pathsub lib%.o, -l%, $(COUNTERS));
 
 sombrero/sombrero6: sombrero/sp4adj/sombrero.o sombrero/sp4adj/hmc_utils.o \
     $(TOPDIR)/LibHR/libhr_sp4adj.a $(COUNTERSFULLPATHS)
 	echo $(_col_link)Linking$(_col_norm) $(call _cfname,$@)... 
-	$(CC) -o $@ $^ $(CFLAGS) -LLibHR -lhr_sp4adj -lm \
+	$(MPICC) -o $@ $^ $(CFLAGS) -LLibHR -lhr_sp4adj -lm \
     -L$(COUNTERSLDIR) $(pathsub lib%.o, -l%, $(COUNTERS));
 
 
@@ -182,7 +182,7 @@ sombrero/sp4/%.o sombrero/sp4adj/%.o : sombrero/%.c $(RBLD)
 	else \
 		echo "$(_col_deps)Compiling$(_col_norm) $(call _cfname,$(call _rname,$(SRC)))..." ;\
 		mkdir -p $(dir $@) ;\
-		$(CC) -o $@ -c $(CFLAGS) $(CPPFLAGS) $< ;\
+		$(MPICC) -o $@ -c $(CFLAGS) $(CPPFLAGS) $< ;\
 	fi ;\
 	
 
@@ -199,7 +199,7 @@ sp4adj/%.o: %.c $(MKDIR)/MkFlags $(RBLD)
 		MAKEFILES="$(DEP)" $(MAKE) $@ ;\
 	else \
 		echo "$(_col_deps)Compiling$(_col_norm) $(call _cfname,$(call _rname,$(SRC)))..." ;\
-		$(CC) -o $@ -c $(CFLAGS) $(CPPFLAGS) $< ;\
+		$(MPICC) -o $@ -c $(CFLAGS) $(CPPFLAGS) $< ;\
 	fi ;\
 
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ make
 ### Setup with Spack
 
 Install and configure the package `sombrero` 
-as you would do with a regular spack package.
+as you would do with a regular Spack package.
 
 ## Usage
 
@@ -39,7 +39,7 @@ To run all benchmarks use the `sombrero.sh` script:
 ./sombrero.sh -n <num-cores>  [ -w ] [ -s small | medium | large | very_large ]
 ```
 
-By default this will run a medium scale problem using `<num-cores>` mpi ranks.
+By default this will run a medium scale problem using `<num-cores>` MPI ranks.
 The problem size is independent of the number of processes. 
 This is useful for strong scaling.
 
@@ -47,7 +47,7 @@ All output is printed to stdout and error messages to stderr.
 
 ### Usage with Spack 
 
-When using spack, once sombrero has been installed,
+When using Spack, once SOMBRERO has been installed,
 loading the `sombrero` package with `spack load sombrero`
 will make `sombrero.sh` available
 in the PATH environment variable,
@@ -60,7 +60,7 @@ sombrero.sh -n <num-cores>  [ -w ] [ -s small | medium | large | very_large ]
 ## Parameters
 
 `-n <num-cores>`: </br>
-&nbsp;&nbsp;&nbsp; Set the number of mpi ranks. SOMBRERO will attempt to divide the problem accross the ranks automatically. The number of ranks `num-cores` should be a power of 2, `num-cores = 2^n`. This can be multiplied by a factor of 3, `num-cores = 3 * 2^n`.
+&nbsp;&nbsp;&nbsp; Set the number of MPI ranks. SOMBRERO will attempt to divide the problem accross the ranks automatically. The number of ranks `num-cores` should be a power of 2, `num-cores = 2^n`. This can be multiplied by a factor of 3, `num-cores = 3 * 2^n`.
 
 `-s small | medium | large | very_large:`</br>
 &nbsp;&nbsp;&nbsp; Specify the problem size. Compatible with weak or strong scaling.
@@ -165,9 +165,9 @@ Additional parameters `-l` and `-p` exist for more precise control of the proble
 &nbsp;&nbsp;&nbsp; Set the lattice size in each direction. Replace each `N` with an integer larger or equal to 4.
 
 `-p NxNxNxN`:</br>
-&nbsp;&nbsp;&nbsp; Manually partition the lattice among the mpi ranks. The lattice is divided accross `N` ranks in each direction. A positive integer must be used.
+&nbsp;&nbsp;&nbsp; Manually partition the lattice among the MPI ranks. The lattice is divided accross `N` ranks in each direction. A positive integer must be used.
 
-Once compiled, binaries for individual test cases can be found in the sombrero folder. For example the case 3 can be run separately with
+Once compiled, binaries for individual test cases can be found in the `sombrero` folder. For example the case 3 can be run separately with
 
 ```
 mpirun -n Np sombrero/sombrero3 -s medium 

--- a/README.md
+++ b/README.md
@@ -8,36 +8,54 @@ A benchmarking utility for high performance computing based on lattice field the
 
 ## Requirements
   
-  Requires an MPI library and compiler.
+Requires an MPI library and compiler.
 
 ## Set Up
 
-  1. Clone the repository
+1. Clone the repository
 
 ```
 git clone https://github.com/sa2c/sombrero.git
 cd sombrero
 ```
 
-  2. Edit `Make/MkFlags` to set the compiler, `CFLAGS` and linker flags
-  3. To compile run
+2. Edit `Make/MkFlags` to set the compiler, `CFLAGS` and linker flags
+3. To compile run
  
 ```
 make
 ```
 
+### Setup with Spack
+
+Install and configure the package `sombrero` 
+as you would do with a regular spack package.
+
 ## Usage
 
-To run all benchmarks use the `sombrero.sh` script
-
+To run all benchmarks use the `sombrero.sh` script:
+  
 ```
 ./sombrero.sh -n <num-cores>  [ -w ] [ -s small | medium | large | very_large ]
 ```
 
-By default this will run a medium scale problem using `<num-cores>` mpi ranks. The problem size independent of the number of processes. This is useful for strong scaling.
+By default this will run a medium scale problem using `<num-cores>` mpi ranks.
+The problem size independent of the number of processes. 
+This is useful for strong scaling.
 
 All output is printed to stdout and error messages to stderr.
 
+### Usage with Spack 
+
+When using spack, once sombrero has been installed,
+loading the `sombrero` package with `spack load sombrero`
+will make `sombrero.sh` available
+in the PATH environment variable,
+so one can use:
+
+```
+sombrero.sh -n <num-cores>  [ -w ] [ -s small | medium | large | very_large ]
+```
 
 ## Parameters
 

--- a/README.md
+++ b/README.md
@@ -179,3 +179,18 @@ The verbose mode will produce additional information:
 mpirun -n Np sombrero/sombrero3 -s medium -v verbose 
 ```
 
+In case SOMBRERO was installed with Spack,
+in order to run a specific benchmark separately
+one has to use the full path to the executable program.
+To do so, 
+once SOMBRERO is loaded by Spack with the command
+
+``` 
+spack load sombrero
+```
+
+one can run case 3 with
+
+``` 
+mpirun -n 2 $(which sombrero.sh | xargs dirname)/sombrero/sombrero3 -s small
+```

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A benchmarking utility for high performance computing based on lattice field the
   
 Requires an MPI library and compiler.
 
-## Set Up
+## Setup
 
 1. Clone the repository
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ To run all benchmarks use the `sombrero.sh` script:
 ```
 
 By default this will run a medium scale problem using `<num-cores>` mpi ranks.
-The problem size independent of the number of processes. 
+The problem size is independent of the number of processes. 
 This is useful for strong scaling.
 
 All output is printed to stdout and error messages to stderr.

--- a/sombrero.sh
+++ b/sombrero.sh
@@ -61,13 +61,16 @@ while getopts 'n:H:s:whl:p:' opt ; do
     esac
 done
 
+# From https://stackoverflow.com/a/246128/3113564
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 # Run each of the benchmarks, copy output to stdout and the tempfile
-safe_run mpirun $nodes sombrero/sombrero1 $weak $size $partition | tee $tmpfile
-safe_run mpirun $nodes sombrero/sombrero2 $weak $size $partition -v result | tee -a $tmpfile
-safe_run mpirun $nodes sombrero/sombrero3 $weak $size $partition -v result | tee -a $tmpfile
-safe_run mpirun $nodes sombrero/sombrero4 $weak $size $partition -v result | tee -a $tmpfile
-safe_run mpirun $nodes sombrero/sombrero5 $weak $size $partition -v result | tee -a $tmpfile
-safe_run mpirun $nodes sombrero/sombrero6 $weak $size $partition -v result | tee -a $tmpfile 
+touch $tmpfile
+for i in {1..6}
+do 
+    safe_run mpirun $nodes \
+    $SCRIPT_DIR/sombrero/sombrero$i $weak $size $partition -v result |\
+    tee -a $tmpfile
+done
 
 # Calculate the sums of the timings and the flop counts
 time=$(grep RESULT $tmpfile | grep -v "Gflops/seconds" | awk '{s+=$7} END {print s}') 

--- a/sombrero.sh
+++ b/sombrero.sh
@@ -61,16 +61,13 @@ while getopts 'n:H:s:whl:p:' opt ; do
     esac
 done
 
-# From https://stackoverflow.com/a/246128/3113564
-SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 # Run each of the benchmarks, copy output to stdout and the tempfile
-touch $tmpfile
-for i in {1..6}
-do 
-    safe_run mpirun $nodes \
-    $SCRIPT_DIR/sombrero/sombrero$i $weak $size $partition -v result |\
-    tee -a $tmpfile
-done
+safe_run mpirun $nodes sombrero/sombrero1 $weak $size $partition | tee $tmpfile
+safe_run mpirun $nodes sombrero/sombrero2 $weak $size $partition -v result | tee -a $tmpfile
+safe_run mpirun $nodes sombrero/sombrero3 $weak $size $partition -v result | tee -a $tmpfile
+safe_run mpirun $nodes sombrero/sombrero4 $weak $size $partition -v result | tee -a $tmpfile
+safe_run mpirun $nodes sombrero/sombrero5 $weak $size $partition -v result | tee -a $tmpfile
+safe_run mpirun $nodes sombrero/sombrero6 $weak $size $partition -v result | tee -a $tmpfile 
 
 # Calculate the sums of the timings and the flop counts
 time=$(grep RESULT $tmpfile | grep -v "Gflops/seconds" | awk '{s+=$7} END {print s}') 


### PR DESCRIPTION
Mainly:
- Attempted change in `sombrero.sh` to make it callable from wherever,
  reverted after discovering Mosè Giordano's spack package,
  which would be broken by that.
- Commented out whole content of MkFlags, to allow spack to take over.
- CC -> MPICC where relevant
- Readme.

Reminder: the thin branch is used as a base by shoplifter 
to create the full Sombrero application.

The product of shoplifter are then committed to the `shoplifted` branch.
There is no interference between the changes in this pull request
and shoplifter's actions,
so these changes just appear in the shoplifted branch.


