### PR TITLE
Always set `-std=c99` as compiler flag

### DIFF
--- a/Make/MkFlags
+++ b/Make/MkFlags
@@ -1,8 +1,11 @@
+# -*- makefile -*-
+
+override CFLAGS += -std=c99
+
 #Compiler
 # Set these variables either here or in the environment. See
 # https://www.gnu.org/software/make/manual/html_node/Implicit-Variables.html
 # If you are using Spack, leave these commented out
 # (Spack will manage them when building)
 # MPICC = mpicc
-# CFLAGS = -std=c99 -O3
 # LDFLAGS =


### PR DESCRIPTION
This flag isn't something handled by Spack automatically and this library always needs it because of constructs like
https://github.com/sa2c/sombrero/blob/9ea299adb80b1c71446cdf2c555ab57ec2cb2fb0/Include/geometry.h#L40